### PR TITLE
Support AWS SSM Parameter Store

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/terraform-providers/terraform-provider-mysqlx
 
 require (
+	github.com/aws/aws-sdk-go v1.19.39
 	github.com/go-sql-driver/mysql v1.4.0
 	github.com/gofrs/uuid v3.2.0+incompatible
 	github.com/hashicorp/go-version v1.2.0

--- a/mysql/resource_ssm_parameter_user_password.go
+++ b/mysql/resource_ssm_parameter_user_password.go
@@ -1,0 +1,94 @@
+package mysql
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceSSMParameterUserPassword() *schema.Resource {
+	return &schema.Resource{
+		Create: SetUserPasswordFromParameterStore,
+		Read:   ReadParameterStoreUserPassword,
+		Delete: DeleteParameterStoreUserPassword,
+		Schema: map[string]*schema.Schema{
+			"user": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"host": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "localhost",
+			},
+			"parameter_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"triggers": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func SetUserPasswordFromParameterStore(d *schema.ResourceData, meta interface{}) error {
+	conf := meta.(*MySQLConfiguration)
+	db, err := connectToMySQL(conf)
+
+	if err != nil {
+		return err
+	}
+
+	name := d.Get("parameter_name").(string)
+	password, err := getParameter(conf.SSM, name)
+
+	if err != nil {
+		return err
+	}
+
+	requiredVersion, _ := version.NewVersion("8.0.0")
+	currentVersion, err := serverVersion(db)
+
+	if err != nil {
+		return err
+	}
+
+	passSQL := fmt.Sprintf("'%s'", password)
+
+	if currentVersion.LessThan(requiredVersion) {
+		passSQL = fmt.Sprintf("PASSWORD(%s)", passSQL)
+	}
+
+	sql := fmt.Sprintf(
+		"SET PASSWORD FOR '%s'@'%s' = %s",
+		d.Get("user").(string),
+		d.Get("host").(string),
+		passSQL,
+	)
+
+	_, err = db.Exec(sql)
+
+	if err != nil {
+		return err
+	}
+
+	user := fmt.Sprintf("%s@%s", d.Get("user").(string), d.Get("host").(string))
+	d.SetId(user)
+
+	return nil
+}
+
+func ReadParameterStoreUserPassword(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func DeleteParameterStoreUserPassword(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}


### PR DESCRIPTION
Get password from AWS SSM Parameter Store.
Password is not stored in tfstate.

```terraform
provider "mysqlx" {
  endpoint               = "localhost"
  username               = "root2"
  use_parameter_store    = true
  ssm_parameter_password = "/master/password" # Password from Parameter Store
  region                 = "ap-northeast-1"
}

resource "mysqlx_user" "scott" {
  user = "scott"
  host = "localhost"
}

resource "mysqlx_ssm_parameter_user_password" "scott" {
  user           = "scott"
  host           = "localhost"
  parameter_name = "/user/password"  # Password from Parameter Store
}
```