### PR TITLE
Fix proxy chain

### DIFF
--- a/mysql/provider.go
+++ b/mysql/provider.go
@@ -157,7 +157,7 @@ func makeDialer(d *schema.ResourceData) (proxy.Dialer, error) {
 		if err != nil {
 			return nil, err
 		}
-		proxy, err := proxy.FromURL(proxyURL, proxyFromEnv)
+		proxy, err := proxy.FromURL(proxyURL, proxy.Direct)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Passing `proxyFromEnv` when setting proxy in environment variable does not work.

```sh
ssh -N -D 10080 bastion &
export all_proxy="socks5h://127.0.0.1:10080"
terraform apply #=> error
```

