### PR TITLE
Defer connecting to database to resources.

### DIFF
--- a/mysql/data_source_tables.go
+++ b/mysql/data_source_tables.go
@@ -30,7 +30,11 @@ func dataSourceTables() *schema.Resource {
 }
 
 func ShowTables(d *schema.ResourceData, meta interface{}) error {
-	db := meta.(*MySQLConfiguration).Db
+	db, err := connectToMySQL(meta.(*MySQLConfiguration))
+
+	if err != nil {
+		return err
+	}
 
 	database := d.Get("database").(string)
 	pattern := d.Get("pattern").(string)

--- a/mysql/provider.go
+++ b/mysql/provider.go
@@ -152,22 +152,12 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		return dialer.Dial("tcp", network)
 	})
 
-	mysqlConf := &MySQLConfiguration{
+	return &MySQLConfiguration{
 		Config:                 &conf,
 		MaxConnLifetime:        time.Duration(d.Get("max_conn_lifetime_sec").(int)) * time.Second,
 		MaxOpenConns:           d.Get("max_open_conns").(int),
 		ConnectRetryTimeoutSec: time.Duration(d.Get("connect_retry_timeout_sec").(int)) * time.Second,
-	}
-
-	db, err := connectToMySQL(mysqlConf)
-
-	if err != nil {
-		return nil, err
-	}
-
-	mysqlConf.Db = db
-
-	return mysqlConf, nil
+	}, nil
 }
 
 var identQuoteReplacer = strings.NewReplacer("`", "``")

--- a/mysql/resource_grant.go
+++ b/mysql/resource_grant.go
@@ -153,7 +153,11 @@ func supportsRoles(db *sql.DB) (bool, error) {
 }
 
 func CreateGrant(d *schema.ResourceData, meta interface{}) error {
-	db := meta.(*MySQLConfiguration).Db
+	db, err := connectToMySQL(meta.(*MySQLConfiguration))
+
+	if err != nil {
+		return err
+	}
 
 	hasRoles, err := supportsRoles(db)
 	if err != nil {
@@ -229,7 +233,11 @@ func CreateGrant(d *schema.ResourceData, meta interface{}) error {
 }
 
 func ReadGrant(d *schema.ResourceData, meta interface{}) error {
-	db := meta.(*MySQLConfiguration).Db
+	db, err := connectToMySQL(meta.(*MySQLConfiguration))
+
+	if err != nil {
+		return err
+	}
 
 	hasRoles, err := supportsRoles(db)
 	if err != nil {
@@ -276,7 +284,11 @@ func ReadGrant(d *schema.ResourceData, meta interface{}) error {
 }
 
 func UpdateGrant(d *schema.ResourceData, meta interface{}) error {
-	db := meta.(*MySQLConfiguration).Db
+	db, err := connectToMySQL(meta.(*MySQLConfiguration))
+
+	if err != nil {
+		return err
+	}
 
 	hasRoles, err := supportsRoles(db)
 
@@ -351,7 +363,11 @@ func updatePrivileges(d *schema.ResourceData, db *sql.DB, user string, database 
 }
 
 func DeleteGrant(d *schema.ResourceData, meta interface{}) error {
-	db := meta.(*MySQLConfiguration).Db
+	db, err := connectToMySQL(meta.(*MySQLConfiguration))
+
+	if err != nil {
+		return err
+	}
 
 	database := formatDatabaseName(d.Get("database").(string))
 
@@ -422,7 +438,11 @@ func ImportGrant(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceDa
 	user := userHost[0]
 	host := userHost[1]
 
-	db := meta.(*MySQLConfiguration).Db
+	db, err := connectToMySQL(meta.(*MySQLConfiguration))
+
+	if err != nil {
+		return nil, err
+	}
 
 	grants, err := showGrants(db, fmt.Sprintf("'%s'@'%s'", user, host))
 

--- a/mysql/resource_role.go
+++ b/mysql/resource_role.go
@@ -24,14 +24,18 @@ func resourceRole() *schema.Resource {
 }
 
 func CreateRole(d *schema.ResourceData, meta interface{}) error {
-	db := meta.(*MySQLConfiguration).Db
+	db, err := connectToMySQL(meta.(*MySQLConfiguration))
+
+	if err != nil {
+		return err
+	}
 
 	roleName := d.Get("name").(string)
 
 	stmtSQL := fmt.Sprintf("CREATE ROLE '%s'", roleName)
 	log.Printf("[DEBUG] SQL: %s", stmtSQL)
 
-	_, err := db.Exec(stmtSQL)
+	_, err = db.Exec(stmtSQL)
 	if err != nil {
 		return fmt.Errorf("error creating role: %s", err)
 	}
@@ -42,12 +46,16 @@ func CreateRole(d *schema.ResourceData, meta interface{}) error {
 }
 
 func ReadRole(d *schema.ResourceData, meta interface{}) error {
-	db := meta.(*MySQLConfiguration).Db
+	db, err := connectToMySQL(meta.(*MySQLConfiguration))
+
+	if err != nil {
+		return err
+	}
 
 	stmtSQL := fmt.Sprintf("SHOW GRANTS FOR '%s'", d.Id())
 	log.Printf("[DEBUG] SQL: %s", stmtSQL)
 
-	_, err := db.Exec(stmtSQL)
+	_, err = db.Exec(stmtSQL)
 	if err != nil {
 		log.Printf("[WARN] Role (%s) not found; removing from state", d.Id())
 		d.SetId("")
@@ -60,12 +68,16 @@ func ReadRole(d *schema.ResourceData, meta interface{}) error {
 }
 
 func DeleteRole(d *schema.ResourceData, meta interface{}) error {
-	db := meta.(*MySQLConfiguration).Db
+	db, err := connectToMySQL(meta.(*MySQLConfiguration))
+
+	if err != nil {
+		return err
+	}
 
 	stmtSQL := fmt.Sprintf("DROP ROLE '%s'", d.Get("name").(string))
 	log.Printf("[DEBUG] SQL: %s", stmtSQL)
 
-	_, err := db.Exec(stmtSQL)
+	_, err = db.Exec(stmtSQL)
 	if err != nil {
 		return err
 	}

--- a/mysql/resource_sql.go
+++ b/mysql/resource_sql.go
@@ -33,13 +33,18 @@ func resourceSql() *schema.Resource {
 }
 
 func CreateSql(d *schema.ResourceData, meta interface{}) error {
-	db := meta.(*MySQLConfiguration).Db
+	db, err := connectToMySQL(meta.(*MySQLConfiguration))
+
+	if err != nil {
+		return err
+	}
+
 	name := d.Get("name").(string)
 	create_sql := d.Get("create_sql").(string)
 
 	log.Println("Executing SQL", create_sql)
 
-	_, err := db.Exec(create_sql)
+	_, err = db.Exec(create_sql)
 
 	if err != nil {
 		return err
@@ -55,12 +60,17 @@ func ReadSql(d *schema.ResourceData, meta interface{}) error {
 }
 
 func DeleteSql(d *schema.ResourceData, meta interface{}) error {
-	db := meta.(*MySQLConfiguration).Db
+	db, err := connectToMySQL(meta.(*MySQLConfiguration))
+
+	if err != nil {
+		return err
+	}
+
 	delete_sql := d.Get("delete_sql").(string)
 
 	log.Println("Executing SQL:", delete_sql)
 
-	_, err := db.Exec(delete_sql)
+	_, err = db.Exec(delete_sql)
 
 	if err == nil {
 		d.SetId("")

--- a/mysql/resource_user_password.go
+++ b/mysql/resource_user_password.go
@@ -45,7 +45,11 @@ func resourceUserPassword() *schema.Resource {
 }
 
 func SetUserPassword(d *schema.ResourceData, meta interface{}) error {
-	db := meta.(*MySQLConfiguration).Db
+	db, err := connectToMySQL(meta.(*MySQLConfiguration))
+
+	if err != nil {
+		return err
+	}
 
 	uuid, err := uuid.NewV4()
 	if err != nil {


### PR DESCRIPTION
It seems like the way database connections are established was changed from 1.10.

From 1.10 onwards, the connection is established in the provider config. This differs from <= 1.9 where the connection is only established when the resource or datasource itself is invoked.

The effect the 1.10 change has is that when a database instance is due to be created and interpolated into the provider, there is no address yet available. This results in the provider attempting to connect to `127.0.0.1:3306`.

This PR reverts only the method of connection, and defers the actual connection to the database only when the resource or datasource is invoked (similar to what happens in 1.9).

This is an example of a terraform config that fails:

```
resource google_sql_database_instance db {
  name = "mydb"
  region = "europe-west4"
  database_version = "MYSQL_8_0"
  ip_configuration {
    ipv4_enabled = ture
  }
}

provider mysql {
  endpoint = google_sql_database_instance.db.public_ip_address
  username = "myusername"
  password = "mypassword"
}
```

This results in the debug logs containing messages like this:

```
2021-04-21T14:24:06.876+0200 [DEBUG] plugin.terraform-provider-mysql_v1.10.2: 2021/04/21 14:24:06 [DEBUG] Waiting for state to become: [success]
2021-04-21T14:24:06.876+0200 [DEBUG] plugin.terraform-provider-mysql_v1.10.2: 2021/04/21 14:24:06 [TRACE] Waiting 500ms before next try
2021-04-21T14:24:07.382+0200 [DEBUG] plugin.terraform-provider-mysql_v1.10.2: 2021/04/21 14:24:07 [TRACE] Waiting 1s before next try
2021-04-21T14:24:08.384+0200 [DEBUG] plugin.terraform-provider-mysql_v1.10.2: 2021/04/21 14:24:08 [TRACE] Waiting 2s before next try
2021-04-21T14:24:10.389+0200 [DEBUG] plugin.terraform-provider-mysql_v1.10.2: 2021/04/21 14:24:10 [TRACE] Waiting 4s before next try
```

before ultimately failing with this error:

```
Error: Could not connect to server: dial tcp 127.0.0.1:3306: connect: connection refused
```