### PR TITLE
Fix 'Database not selected' error on privileges change

### DIFF
--- a/mysql/resource_grant.go
+++ b/mysql/resource_grant.go
@@ -303,7 +303,7 @@ func UpdateGrant(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	database := d.Get("database").(string)
+	database := formatDatabaseName(d.Get("database").(string))
 	table := d.Get("table").(string)
 
 	if d.HasChange("privileges") {


### PR DESCRIPTION
There was an error in SQL statement for database names, that require escaping, if privileges change (add or remove):

```bash
module.database.mysql_grant.db_user_grant[0]: Modifying... [id=me-test-user@%:`me-test`]
2021-06-20T22:05:37.496+0500 [INFO]  Starting apply for module.database.mysql_grant.db_user_grant[0]
2021-06-20T22:05:37.496+0500 [DEBUG] module.database.mysql_grant.db_user_grant[0]: applying the planned Update change
2021-06-20T22:05:37.502+0500 [DEBUG] provider.terraform-provider-mysql_v1.10.3: 2021/06/20 22:05:37 [DEBUG] Waiting for state to become: [success]
2021-06-20T22:05:37.502+0500 [DEBUG] provider.terraform-provider-mysql_v1.10.3: 2021/06/20 22:05:37 [DEBUG] SQL: REVOKE ALL PRIVILEGES ON me-test.* FROM 'me-test-user'@'%'
╷
│ Error: Error 1046: No database selected
│ 
│   with module.database.mysql_grant.db_user_grant[0],
│   on ../../modules/database/mysql.tf line 15, in resource "mysql_grant" "db_user_grant":
│   15: resource "mysql_grant" "db_user_grant" {
│ 
╵
2021-06-20T22:05:37.617+0500 [DEBUG] provider: plugin process exited: path=.terraform/providers/registry.terraform.io/winebarrel/mysql/1.10.3/linux_amd64/terraform-provider-mysql_v1.10.3 pid=290763
2021-06-20T22:05:37.617+0500 [DEBUG] provider: plugin exited

```