### PR TITLE
mysql_grant: Fix the read of grant option.

### DIFF
--- a/mysql/resource_grant.go
+++ b/mysql/resource_grant.go
@@ -268,10 +268,10 @@ func ReadGrant(d *schema.ResourceData, meta interface{}) error {
 	for _, grant := range grants {
 		if grant.Database == database && grant.Table == table {
 			privileges = grant.Privileges
-		}
-
-		if grant.Grant {
-			grantOption = true
+			if grant.Grant {
+				grantOption = true
+			}
+			break
 		}
 	}
 


### PR DESCRIPTION
# Grant option

If multiple `mysql_grant` are defined for the same user,
the grant value of the last one (if true) will be set for all of them in `ReadGrant`.

The example (that I used in the acceptance tests) to reproduce this bug:

```hcl
terraform {
  required_providers {
    mysql = {
      source = "winebarrel/mysql"
    }
  }
}

resource "mysql_database" "db1" {
  name = "db1"
}

resource "mysql_database" "db2" {
  name = "db2"
}

resource "mysql_user" "test" {
  user = "test"
  host = "%"
}

resource "mysql_grant" "test_db1" {
  user       = mysql_user.test.user
  host       = mysql_user.test.host
  database   = mysql_database.db1.name
  privileges = ["SELECT"]
}

resource "mysql_grant" "test_db2" {
  user       = mysql_user.test.user
  host       = mysql_user.test.host
  database   = mysql_database.db2.name
  privileges = ["SELECT"]
  grant      = true
}
```

After the first apply of these resources, there will be a dirty plan:

```bash
●examples❯ terraform apply -auto-approve
[...]
mysql_database.db2: Creating...
mysql_user.test: Creating...
mysql_database.db1: Creating...
mysql_user.test: Creation complete after 0s [id=test@%]
mysql_database.db1: Creation complete after 0s [id=db1]
mysql_database.db2: Creation complete after 0s [id=db2]
mysql_grant.test_db1: Creating...
mysql_grant.test_db2: Creating...
mysql_grant.test_db2: Creation complete after 0s [id=test@%:`db2`]
mysql_grant.test_db1: Creation complete after 0s [id=test@%:`db1`]

Apply complete! Resources: 5 added, 0 changed, 0 destroyed.

●examples❯ terraform plan
mysql_user.test: Refreshing state... [id=test@%]
mysql_database.db1: Refreshing state... [id=db1]
mysql_database.db2: Refreshing state... [id=db2]
mysql_grant.test_db2: Refreshing state... [id=test@%:`db2`]
mysql_grant.test_db1: Refreshing state... [id=test@%:`db1`]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # mysql_grant.test_db1 must be replaced
-/+ resource "mysql_grant" "test_db1" {
      ~ grant      = true -> false # forces replacement
      ~ id         = "test@%:`db1`" -> (known after apply)
        # (6 unchanged attributes hidden)
    }

Plan: 1 to add, 0 to change, 1 to destroy.
```


Terraform version:
```sh
$ terraform version
Terraform v1.0.2
on linux_amd64
+ provider registry.terraform.io/winebarrel/mysql v1.10.4
```


# Import of mysql_grant

As issues are not available on this repo, I allow myself to report here another issue I saw when reading the code (that I didn't fixed in this PR).
The import of `mysql_grant` resources cannot work (while it's declared in the code) as the `ImportGrant` is expecting a `user@host` format where the generated ID are in `users@host:database` format.

```sh
terraform import mysql_grant.test test_user@%:test
mysql_grant.test: Importing from ID "test_user@%:test"...
╷
│ Error: Error 1141: There is no such grant defined for user 'test_user' on host '%:test'
```
Another problem I saw, is that this ID is generated based on (`user`, `host`, `database`) fields, when the uniqueness of this resource seems to be based on  (`user`, `host`, `database`, `table`).
So if one declares 2 `mysql_grant` for 2 different tables in the same database, both resource will have the same ID.