### PR TITLE
Allow Import of user/grant containing "@" in the username.

### DIFF
--- a/mysql/resource_grant.go
+++ b/mysql/resource_grant.go
@@ -432,7 +432,7 @@ func ImportGrant(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceDa
 	}
 
 	user := d.Id()[0:lastSeparatorIndex]
-	host := d.Id()[lastSeparatorIndex:]
+	host := d.Id()[lastSeparatorIndex+1:]
 
 	db, err := meta.(*MySQLConfiguration).GetDbConn()
 	if err != nil {

--- a/mysql/resource_grant.go
+++ b/mysql/resource_grant.go
@@ -425,14 +425,14 @@ func DeleteGrant(d *schema.ResourceData, meta interface{}) error {
 }
 
 func ImportGrant(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	userHost := strings.SplitN(d.Id(), "@", 2)
+	lastSeparatorIndex := strings.LastIndex(d.Id(), "@")
 
-	if len(userHost) != 2 {
+	if lastSeparatorIndex <= 0 {
 		return nil, fmt.Errorf("wrong ID format %s (expected USER@HOST)", d.Id())
 	}
 
-	user := userHost[0]
-	host := userHost[1]
+	user := d.Id()[0:lastSeparatorIndex]
+	host := d.Id()[lastSeparatorIndex:]
 
 	db, err := meta.(*MySQLConfiguration).GetDbConn()
 	if err != nil {

--- a/mysql/resource_user.go
+++ b/mysql/resource_user.go
@@ -259,7 +259,7 @@ func ImportUser(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceDat
 	}
 
 	user := d.Id()[0:lastSeparatorIndex]
-	host := d.Id()[lastSeparatorIndex:]
+	host := d.Id()[lastSeparatorIndex+1:]
 
 	db, err := meta.(*MySQLConfiguration).GetDbConn()
 	if err != nil {

--- a/mysql/resource_user.go
+++ b/mysql/resource_user.go
@@ -252,14 +252,14 @@ func DeleteUser(d *schema.ResourceData, meta interface{}) error {
 }
 
 func ImportUser(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	userHost := strings.SplitN(d.Id(), "@", 2)
+	lastSeparatorIndex := strings.LastIndex(d.Id(), "@")
 
-	if len(userHost) != 2 {
+	if lastSeparatorIndex <= 0 {
 		return nil, fmt.Errorf("wrong ID format %s (expected USER@HOST)", d.Id())
 	}
 
-	user := userHost[0]
-	host := userHost[1]
+	user := d.Id()[0:lastSeparatorIndex]
+	host := d.Id()[lastSeparatorIndex:]
 
 	db, err := meta.(*MySQLConfiguration).GetDbConn()
 	if err != nil {


### PR DESCRIPTION
We are using emails as usernames, therefore an @ is used in the username.
This causes problems on importing the existing users into the statefile.