### PR TITLE
fix: remove hasRole condition from grant option

### DIFF
--- a/mysql/resource_grant.go
+++ b/mysql/resource_grant.go
@@ -211,7 +211,7 @@ func CreateGrant(d *schema.ResourceData, meta interface{}) error {
 		stmtSQL += fmt.Sprintf(" REQUIRE %s", d.Get("tls_option").(string))
 	}
 
-	if !hasRoles && !isRole && d.Get("grant").(bool) {
+	if !isRole && d.Get("grant").(bool) {
 		stmtSQL += " WITH GRANT OPTION"
 	}
 


### PR DESCRIPTION
This condition does not have a sense. To add `WITH GRANT OPTION` to a privileges mysql with version `>=8.0.0` is required, but it's not true.

I'm sure that travis is not working, because i don't see any github checks. 

I tested locally with mysql 5.7:
```
=== RUN   TestAccGrant
--- PASS: TestAccGrant (0.13s)
=== RUN   TestAccGrant_grantOption
--- PASS: TestAccGrant_grantOption (0.10s)
```

and with mysql 8.0:
```
=== RUN   TestAccGrant
--- PASS: TestAccGrant (1.49s)
=== RUN   TestAccGrant_grantOption
    testing.go:569: Step 0 error: Check failed: Check 11/11 error: mysql_grant.test_db2: Attribute 'grant' expected "true", got "false"
--- FAIL: TestAccGrant_grantOption (1.46s)
```

After merge tests should pass.