### PR TITLE
Handle grants on multiple columns of a table

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ on:
       - 'feature/add-complex-grants-support'
 jobs:
   goreleaser:
-    runs-on: tf-registry
+    runs-on: tf-registry-provider-mysql
     steps:
       -
         name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,11 @@ on:
   push:
     tags:
       - 'v*'
+    branches:
+      - 'feature/add-complex-grants-support'
 jobs:
   goreleaser:
-    runs-on: ubuntu-latest
+    runs-on: tf-registry
     steps:
       -
         name: Checkout
@@ -36,12 +38,19 @@ jobs:
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
+      # -
+      #   name: Run GoReleaser
+      #   uses: goreleaser/goreleaser-action@v3
+      #   with:
+      #     version: latest
+      #     args: release
+      #   env:
+      #     GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+      #     GITHUB_TOKEN: ${{ secrets.TOKEN }}
       -
-        name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          version: latest
-          args: release --rm-dist
-        env:
-          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
-          GITHUB_TOKEN: ${{ secrets.TOKEN }}
+        name: Test ref name
+        run: echo ${{github.ref_name}}
+      # -
+      #   name: Publish provider
+      #   run: /home/ec2-user/citizen-linux-x64 provider --registry http://localhost:3000 stable mysql ${{ steps.module-version.outputs.data }}
+      #   working-directory: dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,12 @@
 # This GitHub action can publish assets for release when a tag is created.
 # Currently its setup to run on any tag that matches the pattern "v*" (ie. v0.1.0).
 #
-# This uses an action (paultyng/ghaction-import-gpg) that assumes you set your 
-# private key in the `GPG_PRIVATE_KEY` secret and passphrase in the `PASSPHRASE`
+# This uses an action (crazy-max/ghaction-import-gpg@v5) that assumes you set your
+# private key in the `gpg_private_key` secret and passphrase in the `passphrase`
 # secret. If you would rather own your own GPG handling, please fork this action
 # or use an alternative one for key handling.
 #
-# You will need to pass the `--batch` flag to `gpg` in your signing step 
+# You will need to pass the `--batch` flag to `gpg` in your signing step
 # in `goreleaser` to indicate this is being used in a non-interactive mode.
 #
 name: release
@@ -32,16 +32,16 @@ jobs:
       -
         name: Import GPG key
         id: import_gpg
-        uses: paultyng/ghaction-import-gpg@v2.1.0
-        env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+        uses: crazy-max/ghaction-import-gpg@v5
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PASSPHRASE }}
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v3
         with:
           version: latest
           args: release --rm-dist
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,28 +16,20 @@ builds:
     ldflags:
       - "-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}"
     goos:
-      - freebsd
-      - windows
       - linux
       - darwin
     goarch:
       - amd64
-      - "386"
-      - arm
       - arm64
     ignore:
-      - goos: darwin
-        goarch: "386"
-      - goos: windows
-        goarch: arm
-      - goos: windows
+      - goos: linux
         goarch: arm64
-    binary: "{{ .ProjectName }}_v{{ .Version }}"
+    binary: "stable-mysql_v{{ .Version }}"
 archives:
   - format: zip
-    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    name_template: "stable-mysql_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 checksum:
-  name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
+  name_template: "stable-mysql_{{ .Version }}_SHA256SUMS"
   algorithm: sha256
 signs:
   - artifacts: checksum

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,6 +28,10 @@ builds:
     ignore:
       - goos: darwin
         goarch: "386"
+      - goos: windows
+        goarch: arm
+      - goos: windows
+        goarch: arm64
     binary: "{{ .ProjectName }}_v{{ .Version }}"
 archives:
   - format: zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.10.7 (August 8, 2022)
+
+FEATURES:
+* New way of handling `grants` ([#1](https://github.com/bitvavo/terraform-provider-mysql/pull/1))
+
+...
+
 ## 1.9.1 (Unreleased)
 ## 1.9.0 (November 07, 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.10.8 (August 29, 2022)
+
+FEATURES:
+* Updated read complex `grants` ([#2](https://github.com/bitvavo/terraform-provider-mysql/pull/2))
+
 ## 1.10.7 (August 8, 2022)
 
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.10.8 (August 29, 2022)
 
 FEATURES:
-* Updated read complex `grants` ([#2](https://github.com/bitvavo/terraform-provider-mysql/pull/2))
+* Updated read complex `grants` ([#6](https://github.com/bitvavo/terraform-provider-mysql/pull/6))
 
 ## 1.10.7 (August 8, 2022)
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,9 @@
 
 ---
 
-Terraform Provider
-==================
+# Terraform Provider
 
-Publish
--------
+## Publish
 
 Packages for version and different os_architecture are generated with `.goreleaser.yaml`, triggered by pushing a new `git tag`
 
@@ -29,8 +27,9 @@ ex:
 CITIZEN_ADDR=http://localhost:3000  ./citizen-macos-amd64 provider stable mysql 0.0.1 -v
 ```
 
-Usage
------
+---
+
+## Usage
 
 ```hcl
 terraform {

--- a/README.md
+++ b/README.md
@@ -5,6 +5,30 @@
 Terraform Provider
 ==================
 
+Publish
+-------
+
+Packages for version and different os_architecture are generated with `.goreleaser.yaml`, triggered by pushing a new `git tag`
+
+### Manual build and publish to private terraform registry using [citizen](https://github.com/outsideris/citizen/)
+
+Before publishing an executable is required, executable is found in the releases page on the specific version of the private tf registry that is needed(example: [v0.5.2](https://github.com/outsideris/citizen/releases/tag/v0.5.2))
+
+```sh
+env GOOS=target-OS GOARCH=target-architecture make build
+```
+
+A zip archive format is required by the private terraform registry, multiple os_architecture builds under the same name and version will be uploaded together:
+
+```sh
+zip stable-mysql_0.0.1_<target-OS>_<target-architecture>.zip terraform-provider-mysql
+ex:
+  stable-mysql_0.0.1_darwin_arm64.zip
+  stable-mysql_0.0.1_linux_amd64.zip
+
+CITIZEN_ADDR=http://localhost:3000  ./citizen-macos-amd64 provider stable mysql 0.0.1 -v
+```
+
 Usage
 -----
 
@@ -12,8 +36,8 @@ Usage
 terraform {
   required_providers {
     mysql = {
-      source  = "winebarrel/mysql"
-      version = "~> 1.10.2"
+      source  = "localhost/stable/mysql"
+      version = "~> 0.0.1"
     }
   }
   required_version = ">= 0.13"
@@ -22,5 +46,13 @@ terraform {
 provider "mysql" {
   endpoint = "localhost"
   username = "root"
+}
+
+resource "mysql_grant" "test_db1" {
+  user       = "test"
+  host       = "%"
+  database   = "db"
+  table      = "table"
+  privileges = [ "SELECT", "INSERT (`column1`), "UPDATE (`column1`, `column2`, `column3`)""]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -52,6 +52,6 @@ resource "mysql_grant" "test_db1" {
   host       = "%"
   database   = "db"
   table      = "table"
-  privileges = [ "SELECT", "INSERT (`column1`), "UPDATE (`column1`, `column2`, `column3`)""]
+  privileges = [ "SELECT", "INSERT (`column1`)", "UPDATE (`column1`, `column2`, `column3`)"]
 }
 ```

--- a/mysql/resource_grant.go
+++ b/mysql/resource_grant.go
@@ -502,7 +502,9 @@ func showGrants(db *sql.DB, user string) ([]*MySQLGrant, error) {
 		}
 
 		privsStr := m[1]
-		priv_list := strings.Split(privsStr, ",")
+		rem1 := regexp.MustCompile("[a-zA-Z]+\\ ?\\([a-zA-Z0-9_,\\ `]+\\)|[a-zA-Z]+")
+		priv_list := rem1.FindAllString(privsStr, -1)
+
 		privileges := make([]string, len(priv_list))
 
 		for i, priv := range priv_list {

--- a/mysql/resource_grant.go
+++ b/mysql/resource_grant.go
@@ -502,7 +502,7 @@ func showGrants(db *sql.DB, user string) ([]*MySQLGrant, error) {
 		}
 
 		privsStr := m[1]
-		rem1 := regexp.MustCompile("[a-zA-Z]+\\ ?\\([a-zA-Z0-9_,\\ `]+\\)|[a-zA-Z]+")
+		rem1 := regexp.MustCompile("[A-Z]+\\ ?\\([a-zA-Z0-9_,\\ `]+\\)|[A-Z]+ [A-Z]+ [A-Z]+|[A-Z]+ [A-Z]+|[A-Z]+")
 		priv_list := rem1.FindAllString(privsStr, -1)
 
 		privileges := make([]string, len(priv_list))


### PR DESCRIPTION
This PR improves logic of `showGrants()` in `mysql/resource_grant.go` in order to be able to handle grants on specific columns: `SELECT (a, b, c, d)`

example usage:
```
resource "mysql_grant" "test_db1" {
  user       = "test"
  host       = "%"
  database   = "db1"
  table      = "test"
  privileges = ["SELECT", "UPDATE (`column1`, `column2`, `column3`)"]
}
```